### PR TITLE
Add EL 8 as supported OS version for usage with Centos / RHEL

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
 
     - name: Fedora
       versions:


### PR DESCRIPTION
As Centos / RHEL 8 still use firewalld it would be nice add support to this role. From what we seen internally there should be no more work involved.